### PR TITLE
Fix repeat calls to SetNextVideo()

### DIFF
--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -210,15 +210,6 @@ namespace ScreenSaver
         private void player_PlayStateChange(object sender, AxWMPLib._WMPOCXEvents_PlayStateChangeEvent e)
         {
             NativeMethods.EnableMonitorSleep();
-            
-            var state = this.player.playState;
-            Trace.WriteLine("OnPlayerChanged: " + state + ", new state: " + (WMPLib.WMPPlayState)e.newState);
-            if (//state == WMPLib.WMPPlayState.wmppsReady ||
-                state == WMPLib.WMPPlayState.wmppsUndefined ||
-                state == WMPLib.WMPPlayState.wmppsStopped)
-            {
-                SetNextVideo();
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
With these lines included every time the screensaver transitions from one movie to another SetNextVideo() is called three times.

Crude debugging but, with these lines you get something like this...

	17/12/2015 00:03:19 NextVideoTimer_Tick - current is wmppsPlaying
	17/12/2015 00:03:19 player_PlayStateChange - current is wmppsMediaEnded, new state: wmppsMediaEnded
	17/12/2015 00:03:19 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:19 player_PlayStateChange - current is wmppsStopped, new state: wmppsStopped
	17/12/2015 00:03:19 SetNextVideo
	17/12/2015 00:03:19 Playing from C:\Users\alistair\AppData\Local\Aerial\b1-2.mov
	17/12/2015 00:03:19 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:19 player_PlayStateChange - current is wmppsReady, new state: wmppsReady
	17/12/2015 00:03:19 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsStopped, new state: wmppsStopped
	17/12/2015 00:03:20 SetNextVideo
	17/12/2015 00:03:20 Playing from C:\Users\alistair\AppData\Local\Aerial\b4-2.mov
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsReady, new state: wmppsReady
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsReady, new state: wmppsReady
	17/12/2015 00:03:20 NextVideoTimer_Tick - current is wmppsReady
	17/12/2015 00:03:20 SetNextVideo
	17/12/2015 00:03:20 Playing from C:\Users\alistair\AppData\Local\Aerial\b7-3.mov
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:03:20 player_PlayStateChange - current is wmppsPlaying, new state: wmppsPlaying
	17/12/2015 00:03:21 NextVideoTimer_Tick - current is wmppsPlaying

If you take them out, SetNextVideo is only called once each time...

	17/12/2015 00:55:09 NextVideoTimer_Tick - current is wmppsPlaying
	17/12/2015 00:55:09 player_PlayStateChange - current is wmppsMediaEnded, new state: wmppsMediaEnded
	17/12/2015 00:55:09 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:55:09 player_PlayStateChange - current is wmppsStopped, new state: wmppsStopped
	17/12/2015 00:55:10 NextVideoTimer_Tick - current is wmppsStopped
	17/12/2015 00:55:10 SetNextVideo
	17/12/2015 00:55:10 Playing from C:\Users\alistair\AppData\Local\Aerial\b5-3.mov
	17/12/2015 00:55:10 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:55:10 player_PlayStateChange - current is wmppsReady, new state: wmppsReady
	17/12/2015 00:55:10 player_PlayStateChange - current is wmppsTransitioning, new state: wmppsTransitioning
	17/12/2015 00:55:10 player_PlayStateChange - current is wmppsPlaying, new state: wmppsPlaying
	17/12/2015 00:55:11 NextVideoTimer_Tick - current is wmppsPlaying

