### PR TITLE
Fix for incomplete downloads

### DIFF
--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -142,7 +142,9 @@ namespace ScreenSaver
 
         private void OnDownloadFileComplete(object sender, AsyncCompletedEventArgs e)
         {
-            Directory.Move(Path.Combine(tempFolder, e.UserState.ToString()), Path.Combine(cacheFolder, e.UserState.ToString()));
+			if (e.Cancelled == false && e.Error == null) {
+	            Directory.Move(Path.Combine(tempFolder, e.UserState.ToString()), Path.Combine(cacheFolder, e.UserState.ToString()));
+	        }
         }
 
         private void SetNextVideo()
@@ -164,7 +166,7 @@ namespace ScreenSaver
                     if (cacheVideos) {
                         using (WebClient client = new WebClient())
                         {
-							client.DownloadFileCompleted += new AsyncCompletedEventHandler(OnDownloadFileComplete);
+                            client.DownloadFileCompleted += new AsyncCompletedEventHandler(OnDownloadFileComplete);
                             client.DownloadFileAsync(new System.Uri(Movies[currentVideoIndex].url), Path.Combine(tempFolder, filename), filename);
                         }
                     }

--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -142,9 +142,9 @@ namespace ScreenSaver
 
         private void OnDownloadFileComplete(object sender, AsyncCompletedEventArgs e)
         {
-			if (e.Cancelled == false && e.Error == null) {
+            if (e.Cancelled == false && e.Error == null) {
 	            Directory.Move(Path.Combine(tempFolder, e.UserState.ToString()), Path.Combine(cacheFolder, e.UserState.ToString()));
-	        }
+            }
         }
 
         private void SetNextVideo()


### PR DESCRIPTION
I’ve noticed a few times that the screensaver can copy incomplete
videos from Temp to Cache. And the WMP component can’t play these
incomplete files causing the screensaver to fail.

Turns out DownloadFileCompleted doesn’t just fire when the download is
complete. You need to check the eventargs to see whether the download
was cancelled or whether there was an error.

Updated the code to only copy the file from Temp to Cache when it
wasn’t cancelled and there was no error.

Also fixed a white space issue on another line that was bugging me. :)