### PR TITLE
Cache fixes

### DIFF
--- a/ScreenSaver/Program.cs
+++ b/ScreenSaver/Program.cs
@@ -39,6 +39,8 @@ namespace ScreenSaver
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
+			ClearPartialDownloads();
+
             if (args.Length > 0)
             {
                 string firstArgument = args[0].ToLower().Trim();
@@ -137,5 +139,23 @@ namespace ScreenSaver
             }
         }
 
+        /// <summary>
+        /// Clear partially downloaded movs from temp folder
+        /// </summary>
+        static void ClearPartialDownloads()
+        {
+            string tempFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp\\Aerial");
+            string[] filenames = Directory.GetFiles(tempFolder, "*.mov", SearchOption.TopDirectoryOnly);
+            foreach (string filename in filenames)
+            {
+                try
+                {
+                    File.Delete(Path.Combine(tempFolder, filename));
+                }
+                catch (IOException ioe)
+                {
+                }
+            }
+        }
     }
 }

--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -163,7 +163,7 @@ namespace ScreenSaver
                 else
                 {
                     player.URL = Movies[currentVideoIndex].url;
-                    if (cacheVideos) {
+                    if (cacheVideos && !File.Exists(Path.Combine(tempFolder, filename))) {
                         using (WebClient client = new WebClient())
                         {
                             client.DownloadFileCompleted += new AsyncCompletedEventHandler(OnDownloadFileComplete);

--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -144,7 +144,13 @@ namespace ScreenSaver
         private void OnDownloadFileComplete(object sender, AsyncCompletedEventArgs e)
         {
             if (e.Cancelled == false && e.Error == null) {
-	            Directory.Move(Path.Combine(tempFolder, e.UserState.ToString()), Path.Combine(cacheFolder, e.UserState.ToString()));
+                try
+                {
+                    Directory.Move(Path.Combine(tempFolder, e.UserState.ToString()), Path.Combine(cacheFolder, e.UserState.ToString()));
+                }
+                catch (IOException ioe)
+                {
+                }
             }
         }
 

--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -22,7 +22,7 @@ namespace ScreenSaver
         DateTime lastInteraction = DateTime.Now;
 
         string cacheFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Aerial");
-        string tempFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp");
+        string tempFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp\\Aerial");
 
         public ScreenSaverForm()
         {
@@ -81,7 +81,8 @@ namespace ScreenSaver
 
             var cacheVideos = new RegSettings().CacheVideos;
             if (cacheVideos) {
-                DirectoryInfo directory = Directory.CreateDirectory(cacheFolder);
+                DirectoryInfo cacheDirectory = Directory.CreateDirectory(cacheFolder);
+                DirectoryInfo tempDirectory = Directory.CreateDirectory(tempFolder);
             }
 
             if (ShowVideo)
@@ -153,7 +154,6 @@ namespace ScreenSaver
             var cacheVideos = new RegSettings().CacheVideos;
             if (ShowVideo)
             {
-                string tempFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp");
                 string filename = Path.GetFileName(Movies[currentVideoIndex].url);
 
                 if (File.Exists(Path.Combine(cacheFolder, filename)))


### PR DESCRIPTION
Mostly a fix for InternalMoveIOException errors that people with multiple monitors are seeing.

I think the bug is caused by each form (i.e. each monitor) attempting to download the same file. And then once the download is complete, one of the forms tries to move the file but can’t because the other form is still writing to it. Resulting in the IOException error.