### PR TITLE
Fix for crashes on start

### DIFF
--- a/ScreenSaver/Caching.cs
+++ b/ScreenSaver/Caching.cs
@@ -17,7 +17,7 @@ public class Caching
     internal static void Setup()
     {
         // If there is no location stored in the Registry, use the default location
-        if (CacheFolder == null)
+        if (CacheFolder == null || CacheFolder == "")
         {
             CacheFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Aerial");
         }

--- a/ScreenSaver/RegSettings.cs
+++ b/ScreenSaver/RegSettings.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Win32;
+using System;
+using System.IO;
 
 namespace ScreenSaver
 {
@@ -9,7 +11,7 @@ namespace ScreenSaver
         public bool UseTimeOfDay = true;
         public bool MultiscreenDisabled = true;
         public bool CacheVideos = true;
-        public string CacheLocation = "";
+        public string CacheLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Aerial");
 
         public RegSettings()
         {

--- a/ScreenSaver/SettingsForm.cs
+++ b/ScreenSaver/SettingsForm.cs
@@ -23,7 +23,7 @@ namespace ScreenSaver
             chkMultiscreenDisabled.Checked = settings.MultiscreenDisabled;
             chkCacheVideos.Checked = settings.CacheVideos;
 
-            if(settings.CacheLocation == null)
+            if(settings.CacheLocation == null || settings.CacheLocation == "")
             {
                 txtCacheFolderPath.Text = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Aerial").ToString();
             }


### PR DESCRIPTION
Fix for #106 and #107.

Crashes were caused by CacheLocation being set to “” if the registry
key didn’t exist which caused the screensaver to crash at
CreateDirectory. Now setting to default location initially.

Added a little more error checking in case the Registry key has
manually been blanked. Which would also cause the screensaver and the
Settings form to crash.