### PR TITLE
Add Span All Monitors option

### DIFF
--- a/ScreenSaver/AerialEntities.cs
+++ b/ScreenSaver/AerialEntities.cs
@@ -47,7 +47,7 @@ namespace Aerial
                 links = urls.SelectMany(s => s.assets).ToList();
             }
 
-            if (settings.DifferentMoviesOnDual)
+            if (settings.MultiMonitorMode == RegSettings.MultiMonitorModeEnum.DifferentVideos)
                 return links;
 
             if (cachedPlaylist == null)

--- a/ScreenSaver/FormsHelpers.cs
+++ b/ScreenSaver/FormsHelpers.cs
@@ -1,0 +1,30 @@
+﻿
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Aerial
+{
+    public static class FormsHelpers
+    {
+        public static void DataBindEnum<T>(this ComboBox combobox, T defaultValue)
+        {
+            var list = Enum.GetValues(typeof(T))
+                .Cast<T>()
+                .Select(x => new
+                {
+                    Value = x,
+                    Description =
+                        (Attribute.GetCustomAttribute(x.GetType().GetField(x.ToString()), typeof(DescriptionAttribute)) as DescriptionAttribute)?.Description
+                        ?? x.ToString()
+                })
+                .OrderBy(x => x.Value)
+                .ToList();
+            combobox.DataSource = list;
+            combobox.DisplayMember = "Description";
+            combobox.ValueMember = "Value";
+            combobox.SelectedValue = defaultValue;
+        }
+    }
+}

--- a/ScreenSaver/FormsHelpers.cs
+++ b/ScreenSaver/FormsHelpers.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -25,6 +26,26 @@ namespace Aerial
             combobox.DisplayMember = "Description";
             combobox.ValueMember = "Value";
             combobox.SelectedValue = defaultValue;
+        }
+
+        /// <summary>
+        /// Gets the bounds of all the specified screens.
+        /// </summary>
+        /// <param name="screens"></param>
+        /// <returns></returns>
+        public static Rectangle GetBounds(this Screen[] screens)
+        {
+            // find edges of all monitors
+            var topMost = screens.Min(x => x.Bounds.Top);
+            var leftMost = screens.Min(x => x.Bounds.Left);
+            var bottomMost = screens.Max(x => x.Bounds.Bottom);
+            var rightMost = screens.Max(x => x.Bounds.Right);
+
+            return new Rectangle(
+                leftMost, 
+                topMost,
+                rightMost - leftMost,
+                bottomMost - topMost);
         }
     }
 }

--- a/ScreenSaver/Program.cs
+++ b/ScreenSaver/Program.cs
@@ -128,18 +128,27 @@ namespace Aerial
         /// </summary>
         static void ShowScreenSaver()
         {
-            int i = 0;
-            var multiscreenDisabled = new RegSettings().MultiMonitorMode == RegSettings.MultiMonitorModeEnum.MainOnly;
-            foreach (Screen screen in Screen.AllScreens)
-            {
-                bool showVideo = true;
-                // disable video on multi-displays (3+) except the first
-                if (Screen.AllScreens.Length > 2 && screen != Screen.PrimaryScreen && multiscreenDisabled)
-                    showVideo = false;
+            var multiMonitorMode = new RegSettings().MultiMonitorMode;
 
-                ScreenSaverForm screensaver = new ScreenSaverForm(screen.Bounds, i == 0, showVideo);
-                screensaver.Show();
-                i++;
+            if (multiMonitorMode == RegSettings.MultiMonitorModeEnum.SpanAll)
+            {
+                new ScreenSaverForm(Screen.AllScreens.GetBounds(), true, true).Show();
+            }
+            else
+            {
+                int i = 0;
+                var multiscreenDisabled = multiMonitorMode == RegSettings.MultiMonitorModeEnum.MainOnly;
+                foreach (Screen screen in Screen.AllScreens)
+                {
+                    bool showVideo = true;
+                    // disable video on multi-displays (3+) except the first
+                    if (Screen.AllScreens.Length > 2 && screen != Screen.PrimaryScreen && multiscreenDisabled)
+                        showVideo = false;
+
+                    ScreenSaverForm screensaver = new ScreenSaverForm(screen.Bounds, i == 0, showVideo);
+                    screensaver.Show();
+                    i++;
+                }
             }
         }
     }

--- a/ScreenSaver/Program.cs
+++ b/ScreenSaver/Program.cs
@@ -129,7 +129,7 @@ namespace Aerial
         static void ShowScreenSaver()
         {
             int i = 0;
-            var multiscreenDisabled = new RegSettings().MultiscreenDisabled;
+            var multiscreenDisabled = new RegSettings().MultiMonitorMode == RegSettings.MultiMonitorModeEnum.MainOnly;
             foreach (Screen screen in Screen.AllScreens)
             {
                 bool showVideo = true;

--- a/ScreenSaver/Program.cs
+++ b/ScreenSaver/Program.cs
@@ -1,6 +1,7 @@
 ﻿using ScreenSaver;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
 
@@ -130,25 +131,31 @@ namespace Aerial
         {
             var multiMonitorMode = new RegSettings().MultiMonitorMode;
 
-            if (multiMonitorMode == RegSettings.MultiMonitorModeEnum.SpanAll)
+            switch (multiMonitorMode)
             {
-                new ScreenSaverForm(Screen.AllScreens.GetBounds(), true, true).Show();
-            }
-            else
-            {
-                int i = 0;
-                var multiscreenDisabled = multiMonitorMode == RegSettings.MultiMonitorModeEnum.MainOnly;
-                foreach (Screen screen in Screen.AllScreens)
-                {
-                    bool showVideo = true;
-                    // disable video on multi-displays (3+) except the first
-                    if (Screen.AllScreens.Length > 2 && screen != Screen.PrimaryScreen && multiscreenDisabled)
-                        showVideo = false;
-
-                    ScreenSaverForm screensaver = new ScreenSaverForm(screen.Bounds, i == 0, showVideo);
-                    screensaver.Show();
-                    i++;
-                }
+                case RegSettings.MultiMonitorModeEnum.SameOnEach:
+                case RegSettings.MultiMonitorModeEnum.DifferentVideos:
+                    {
+                        foreach (var screen in Screen.AllScreens)
+                        {
+                            new ScreenSaverForm(screen.Bounds, shouldCache: screen.Primary, showVideo: true).Show();
+                        }
+                        break;
+                    }
+                case RegSettings.MultiMonitorModeEnum.SpanAll:
+                    {
+                        new ScreenSaverForm(Screen.AllScreens.GetBounds(), shouldCache: true, showVideo: true).Show();
+                        break;
+                    }
+                case RegSettings.MultiMonitorModeEnum.MainOnly:
+                default:
+                    {
+                        foreach (var screen in Screen.AllScreens)
+                        {
+                            new ScreenSaverForm(screen.Bounds, shouldCache: screen.Primary, showVideo: screen.Primary).Show();
+                        }
+                        break;
+                    }
             }
         }
     }

--- a/ScreenSaver/RegSettings.cs
+++ b/ScreenSaver/RegSettings.cs
@@ -55,14 +55,16 @@ namespace Aerial
         {
             RegistryKey key = Registry.CurrentUser.CreateSubKey(keyAddress);
             
-            key.SetValue(nameof(DifferentMoviesOnDual), DifferentMoviesOnDual);
-            key.SetValue(nameof(MultiscreenDisabled), MultiscreenDisabled);
             key.SetValue(nameof(MultiMonitorMode), MultiMonitorMode);
             key.SetValue(nameof(UseTimeOfDay), UseTimeOfDay);
             key.SetValue(nameof(CacheVideos), CacheVideos);
             key.SetValue(nameof(CacheLocation), CacheLocation);
             key.SetValue(nameof(ChosenMovies), ChosenMovies);
             key.SetValue(nameof(JsonURL), JsonURL);
+
+            // delete old keys
+            key.DeleteValue(nameof(DifferentMoviesOnDual), throwOnMissingValue: false);
+            key.DeleteValue(nameof(MultiscreenDisabled), throwOnMissingValue: false);
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/ScreenSaver/RegSettings.cs
+++ b/ScreenSaver/RegSettings.cs
@@ -28,11 +28,7 @@ namespace Aerial
                 DifferentMoviesOnDual = bool.Parse(key.GetValue(nameof(DifferentMoviesOnDual)) as string ?? "True");
                 MultiscreenDisabled = bool.Parse(key.GetValue(nameof(MultiscreenDisabled)) as string ?? "True");
 
-                if (Enum.TryParse<MultiMonitorModeEnum>(key.GetValue(nameof(MultiMonitorMode)) as string, out var parsedMode))
-                {
-                    MultiMonitorMode = parsedMode;
-                }
-                else
+                if (!Enum.TryParse(key.GetValue(nameof(MultiMonitorMode)) as string, out MultiMonitorMode))
                 {
                     // load value from legacy settings
                     MultiMonitorMode =

--- a/ScreenSaver/ScreenSaver.csproj
+++ b/ScreenSaver/ScreenSaver.csproj
@@ -100,6 +100,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="AerialGlobalVars.cs" />
+    <Compile Include="FormsHelpers.cs" />
     <Compile Include="IgnoreMouseClickMessageFilter.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -1,4 +1,4 @@
-﻿using Aerial;
+using Aerial;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -7,7 +7,7 @@ using System.Drawing;
 using System.Net;
 using System.IO;
 using System.Windows.Forms;
-using System.Threading.Tasks;
+using System.Linq;
 
 namespace ScreenSaver
 {
@@ -300,11 +300,27 @@ namespace ScreenSaver
                 videoSize = new Size(1920, 1080);
             }
 
-            this.SetBounds(
-                (screenArea.Width - videoSize.Width) / 2,
-                (screenArea.Height - videoSize.Height) / 2,
-                videoSize.Width,
-                videoSize.Height);
+            if (new RegSettings().MultiMonitorMode == RegSettings.MultiMonitorModeEnum.SpanAll)
+            {
+                // find edges of all monitors
+                var topMost = Screen.AllScreens.Min(x => x.Bounds.Top);
+                var leftMost = Screen.AllScreens.Min(x => x.Bounds.Left);
+                var bottomMost = Screen.AllScreens.Max(x => x.Bounds.Bottom);
+                var rightMost = Screen.AllScreens.Max(x => x.Bounds.Right);
+
+                this.SetBounds(
+                    leftMost, topMost,
+                    rightMost - leftMost,
+                    bottomMost - topMost);
+            }
+            else
+            {
+                this.SetBounds(
+                    (screenArea.Width - videoSize.Width) / 2,
+                    (screenArea.Height - videoSize.Height) / 2,
+                    videoSize.Width,
+                    videoSize.Height);
+            }
         }
 
 

--- a/ScreenSaver/ScreenSaverForm.cs
+++ b/ScreenSaver/ScreenSaverForm.cs
@@ -302,20 +302,12 @@ namespace ScreenSaver
 
             if (new RegSettings().MultiMonitorMode == RegSettings.MultiMonitorModeEnum.SpanAll)
             {
-                // find edges of all monitors
-                var topMost = Screen.AllScreens.Min(x => x.Bounds.Top);
-                var leftMost = Screen.AllScreens.Min(x => x.Bounds.Left);
-                var bottomMost = Screen.AllScreens.Max(x => x.Bounds.Bottom);
-                var rightMost = Screen.AllScreens.Max(x => x.Bounds.Right);
-
-                this.SetBounds(
-                    leftMost, topMost,
-                    rightMost - leftMost,
-                    bottomMost - topMost);
+                var bounds = Screen.AllScreens.GetBounds();
+                SetBounds(bounds.X, bounds.Y, bounds.Width, bounds.Height);
             }
             else
             {
-                this.SetBounds(
+                SetBounds(
                     (screenArea.Width - videoSize.Width) / 2,
                     (screenArea.Height - videoSize.Height) / 2,
                     videoSize.Width,

--- a/ScreenSaver/SettingsForm.Designer.cs
+++ b/ScreenSaver/SettingsForm.Designer.cs
@@ -43,6 +43,7 @@ namespace ScreenSaver
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.chkUseTimeOfDay = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.cbMultiScreenMode = new System.Windows.Forms.ComboBox();
             this.tabCache = new System.Windows.Forms.TabPage();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.numOfCurrDown_lbl = new System.Windows.Forms.Label();
@@ -55,13 +56,12 @@ namespace ScreenSaver
             this.changeCacheLocationButton = new System.Windows.Forms.Button();
             this.txtCacheFolderPath = new System.Windows.Forms.TextBox();
             this.tabSource = new System.Windows.Forms.TabPage();
+            this.SetToFourK_btn = new System.Windows.Forms.Button();
             this.videoSourceResetButton = new System.Windows.Forms.Button();
             this.lbl_VideoSourceURL = new System.Windows.Forms.Label();
             this.changeVideoSourceText = new System.Windows.Forms.TextBox();
             this.tabAbout = new System.Windows.Forms.TabPage();
             this.timerDiskUpdate = new System.Windows.Forms.Timer(this.components);
-            this.SetToFourK_btn = new System.Windows.Forms.Button();
-            this.cbMultiScreenMode = new System.Windows.Forms.ComboBox();
             this.tabs.SuspendLayout();
             this.tabPreferences.SuspendLayout();
             this.grpChosenVideos.SuspendLayout();
@@ -77,10 +77,9 @@ namespace ScreenSaver
             // 
             this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Location = new System.Drawing.Point(16, 473);
-            this.okButton.Margin = new System.Windows.Forms.Padding(4);
+            this.okButton.Location = new System.Drawing.Point(12, 384);
             this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(100, 28);
+            this.okButton.Size = new System.Drawing.Size(75, 23);
             this.okButton.TabIndex = 4;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
@@ -91,10 +90,9 @@ namespace ScreenSaver
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.cancelButton.CausesValidation = false;
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(124, 473);
-            this.cancelButton.Margin = new System.Windows.Forms.Padding(4);
+            this.cancelButton.Location = new System.Drawing.Point(93, 384);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(100, 28);
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 5;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -103,11 +101,10 @@ namespace ScreenSaver
             // lblVersion
             // 
             this.lblVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblVersion.Location = new System.Drawing.Point(274, 476);
-            this.lblVersion.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblVersion.Location = new System.Drawing.Point(206, 387);
             this.lblVersion.Name = "lblVersion";
             this.lblVersion.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.lblVersion.Size = new System.Drawing.Size(284, 28);
+            this.lblVersion.Size = new System.Drawing.Size(213, 23);
             this.lblVersion.TabIndex = 13;
             this.lblVersion.TabStop = true;
             this.lblVersion.Text = "Version Info";
@@ -123,22 +120,20 @@ namespace ScreenSaver
             this.tabs.Controls.Add(this.tabCache);
             this.tabs.Controls.Add(this.tabSource);
             this.tabs.Controls.Add(this.tabAbout);
-            this.tabs.Location = new System.Drawing.Point(16, 14);
-            this.tabs.Margin = new System.Windows.Forms.Padding(4);
+            this.tabs.Location = new System.Drawing.Point(12, 11);
             this.tabs.Name = "tabs";
             this.tabs.SelectedIndex = 0;
-            this.tabs.Size = new System.Drawing.Size(547, 444);
+            this.tabs.Size = new System.Drawing.Size(410, 361);
             this.tabs.TabIndex = 14;
             // 
             // tabPreferences
             // 
             this.tabPreferences.Controls.Add(this.grpChosenVideos);
             this.tabPreferences.Controls.Add(this.groupBox1);
-            this.tabPreferences.Location = new System.Drawing.Point(4, 25);
-            this.tabPreferences.Margin = new System.Windows.Forms.Padding(4);
+            this.tabPreferences.Location = new System.Drawing.Point(4, 22);
             this.tabPreferences.Name = "tabPreferences";
-            this.tabPreferences.Padding = new System.Windows.Forms.Padding(4);
-            this.tabPreferences.Size = new System.Drawing.Size(539, 415);
+            this.tabPreferences.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.tabPreferences.Size = new System.Drawing.Size(402, 335);
             this.tabPreferences.TabIndex = 0;
             this.tabPreferences.Text = "Preferences";
             this.tabPreferences.UseVisualStyleBackColor = true;
@@ -150,11 +145,9 @@ namespace ScreenSaver
             this.grpChosenVideos.Controls.Add(this.player);
             this.grpChosenVideos.Controls.Add(this.pictureBox1);
             this.grpChosenVideos.Controls.Add(this.chkUseTimeOfDay);
-            this.grpChosenVideos.Location = new System.Drawing.Point(9, 92);
-            this.grpChosenVideos.Margin = new System.Windows.Forms.Padding(4);
+            this.grpChosenVideos.Location = new System.Drawing.Point(7, 75);
             this.grpChosenVideos.Name = "grpChosenVideos";
-            this.grpChosenVideos.Padding = new System.Windows.Forms.Padding(4);
-            this.grpChosenVideos.Size = new System.Drawing.Size(519, 313);
+            this.grpChosenVideos.Size = new System.Drawing.Size(389, 254);
             this.grpChosenVideos.TabIndex = 13;
             this.grpChosenVideos.TabStop = false;
             this.grpChosenVideos.Text = "Chosen Videos";
@@ -163,12 +156,11 @@ namespace ScreenSaver
             // 
             this.tvChosen.CheckBoxes = true;
             this.tvChosen.FullRowSelect = true;
-            this.tvChosen.Location = new System.Drawing.Point(8, 23);
-            this.tvChosen.Margin = new System.Windows.Forms.Padding(4);
+            this.tvChosen.Location = new System.Drawing.Point(6, 19);
             this.tvChosen.Name = "tvChosen";
             this.tvChosen.ShowLines = false;
             this.tvChosen.ShowPlusMinus = false;
-            this.tvChosen.Size = new System.Drawing.Size(184, 281);
+            this.tvChosen.Size = new System.Drawing.Size(139, 229);
             this.tvChosen.TabIndex = 19;
             this.tvChosen.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.tvChosen_AfterSelect);
             // 
@@ -177,10 +169,9 @@ namespace ScreenSaver
             this.cbLivePreview.AutoSize = true;
             this.cbLivePreview.Checked = true;
             this.cbLivePreview.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbLivePreview.Location = new System.Drawing.Point(201, 256);
-            this.cbLivePreview.Margin = new System.Windows.Forms.Padding(4);
+            this.cbLivePreview.Location = new System.Drawing.Point(151, 208);
             this.cbLivePreview.Name = "cbLivePreview";
-            this.cbLivePreview.Size = new System.Drawing.Size(109, 21);
+            this.cbLivePreview.Size = new System.Drawing.Size(87, 17);
             this.cbLivePreview.TabIndex = 18;
             this.cbLivePreview.Text = "Live Preview";
             this.cbLivePreview.UseVisualStyleBackColor = true;
@@ -189,7 +180,6 @@ namespace ScreenSaver
             // 
             this.player.Enabled = true;
             this.player.Location = new System.Drawing.Point(151, 19);
-            this.player.Margin = new System.Windows.Forms.Padding(4);
             this.player.Name = "player";
             this.player.OcxState = ((System.Windows.Forms.AxHost.State)(resources.GetObject("player.OcxState")));
             this.player.Size = new System.Drawing.Size(232, 132);
@@ -200,10 +190,9 @@ namespace ScreenSaver
             this.pictureBox1.ErrorImage = null;
             this.pictureBox1.Image = global::Aerial.Properties.Resources.surfacebook;
             this.pictureBox1.InitialImage = global::Aerial.Properties.Resources.surfacebook;
-            this.pictureBox1.Location = new System.Drawing.Point(201, 38);
-            this.pictureBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.pictureBox1.Location = new System.Drawing.Point(151, 31);
             this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(309, 222);
+            this.pictureBox1.Size = new System.Drawing.Size(232, 180);
             this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pictureBox1.TabIndex = 17;
             this.pictureBox1.TabStop = false;
@@ -213,10 +202,9 @@ namespace ScreenSaver
             this.chkUseTimeOfDay.AutoSize = true;
             this.chkUseTimeOfDay.Checked = true;
             this.chkUseTimeOfDay.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkUseTimeOfDay.Location = new System.Drawing.Point(201, 284);
-            this.chkUseTimeOfDay.Margin = new System.Windows.Forms.Padding(4);
+            this.chkUseTimeOfDay.Location = new System.Drawing.Point(151, 231);
             this.chkUseTimeOfDay.Name = "chkUseTimeOfDay";
-            this.chkUseTimeOfDay.Size = new System.Drawing.Size(207, 21);
+            this.chkUseTimeOfDay.Size = new System.Drawing.Size(155, 17);
             this.chkUseTimeOfDay.TabIndex = 14;
             this.chkUseTimeOfDay.Text = "Prioritize current time of day";
             this.chkUseTimeOfDay.UseVisualStyleBackColor = true;
@@ -224,23 +212,30 @@ namespace ScreenSaver
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.cbMultiScreenMode);
-            this.groupBox1.Location = new System.Drawing.Point(8, 7);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Location = new System.Drawing.Point(6, 6);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox1.Size = new System.Drawing.Size(520, 78);
+            this.groupBox1.Size = new System.Drawing.Size(390, 63);
             this.groupBox1.TabIndex = 12;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Multi-screen setups";
             // 
+            // cbMultiScreenMode
+            // 
+            this.cbMultiScreenMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbMultiScreenMode.FormattingEnabled = true;
+            this.cbMultiScreenMode.Location = new System.Drawing.Point(7, 25);
+            this.cbMultiScreenMode.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cbMultiScreenMode.Name = "cbMultiScreenMode";
+            this.cbMultiScreenMode.Size = new System.Drawing.Size(377, 21);
+            this.cbMultiScreenMode.TabIndex = 0;
+            // 
             // tabCache
             // 
             this.tabCache.Controls.Add(this.groupBox2);
-            this.tabCache.Location = new System.Drawing.Point(4, 25);
-            this.tabCache.Margin = new System.Windows.Forms.Padding(4);
+            this.tabCache.Location = new System.Drawing.Point(4, 22);
             this.tabCache.Name = "tabCache";
-            this.tabCache.Padding = new System.Windows.Forms.Padding(4);
-            this.tabCache.Size = new System.Drawing.Size(539, 415);
+            this.tabCache.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.tabCache.Size = new System.Drawing.Size(402, 335);
             this.tabCache.TabIndex = 1;
             this.tabCache.Text = "Cache";
             this.tabCache.UseVisualStyleBackColor = true;
@@ -256,11 +251,9 @@ namespace ScreenSaver
             this.groupBox2.Controls.Add(this.chkCacheVideos);
             this.groupBox2.Controls.Add(this.changeCacheLocationButton);
             this.groupBox2.Controls.Add(this.txtCacheFolderPath);
-            this.groupBox2.Location = new System.Drawing.Point(9, 7);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Location = new System.Drawing.Point(7, 6);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBox2.Size = new System.Drawing.Size(519, 398);
+            this.groupBox2.Size = new System.Drawing.Size(389, 323);
             this.groupBox2.TabIndex = 16;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Cache";
@@ -268,18 +261,19 @@ namespace ScreenSaver
             // numOfCurrDown_lbl
             // 
             this.numOfCurrDown_lbl.AutoSize = true;
-            this.numOfCurrDown_lbl.Location = new System.Drawing.Point(333, 57);
+            this.numOfCurrDown_lbl.Location = new System.Drawing.Point(250, 46);
+            this.numOfCurrDown_lbl.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.numOfCurrDown_lbl.Name = "numOfCurrDown_lbl";
-            this.numOfCurrDown_lbl.Size = new System.Drawing.Size(152, 17);
+            this.numOfCurrDown_lbl.Size = new System.Drawing.Size(116, 13);
             this.numOfCurrDown_lbl.TabIndex = 21;
             this.numOfCurrDown_lbl.Text = "# of files downloading: ";
             // 
             // fullDownloadBtn
             // 
-            this.fullDownloadBtn.Location = new System.Drawing.Point(308, 22);
-            this.fullDownloadBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.fullDownloadBtn.Location = new System.Drawing.Point(231, 18);
+            this.fullDownloadBtn.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.fullDownloadBtn.Name = "fullDownloadBtn";
-            this.fullDownloadBtn.Size = new System.Drawing.Size(203, 29);
+            this.fullDownloadBtn.Size = new System.Drawing.Size(152, 24);
             this.fullDownloadBtn.TabIndex = 20;
             this.fullDownloadBtn.Text = "Download All Videos";
             this.fullDownloadBtn.UseVisualStyleBackColor = true;
@@ -288,19 +282,17 @@ namespace ScreenSaver
             // lblFreeSpace
             // 
             this.lblFreeSpace.AutoSize = true;
-            this.lblFreeSpace.Location = new System.Drawing.Point(21, 135);
-            this.lblFreeSpace.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblFreeSpace.Location = new System.Drawing.Point(16, 110);
             this.lblFreeSpace.Name = "lblFreeSpace";
-            this.lblFreeSpace.Size = new System.Drawing.Size(146, 17);
+            this.lblFreeSpace.Size = new System.Drawing.Size(111, 13);
             this.lblFreeSpace.TabIndex = 19;
             this.lblFreeSpace.Text = "Free Space Available:";
             // 
             // btnPurgeCache
             // 
-            this.btnPurgeCache.Location = new System.Drawing.Point(308, 129);
-            this.btnPurgeCache.Margin = new System.Windows.Forms.Padding(4);
+            this.btnPurgeCache.Location = new System.Drawing.Point(231, 105);
             this.btnPurgeCache.Name = "btnPurgeCache";
-            this.btnPurgeCache.Size = new System.Drawing.Size(203, 28);
+            this.btnPurgeCache.Size = new System.Drawing.Size(152, 23);
             this.btnPurgeCache.TabIndex = 18;
             this.btnPurgeCache.Text = "Delete Cache";
             this.btnPurgeCache.UseVisualStyleBackColor = true;
@@ -309,19 +301,17 @@ namespace ScreenSaver
             // lblCacheSize
             // 
             this.lblCacheSize.AutoSize = true;
-            this.lblCacheSize.Location = new System.Drawing.Point(21, 106);
-            this.lblCacheSize.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblCacheSize.Location = new System.Drawing.Point(16, 86);
             this.lblCacheSize.Name = "lblCacheSize";
-            this.lblCacheSize.Size = new System.Drawing.Size(134, 17);
+            this.lblCacheSize.Size = new System.Drawing.Size(101, 13);
             this.lblCacheSize.TabIndex = 17;
             this.lblCacheSize.Text = "Current Cache Size:";
             // 
             // btnOpenCache
             // 
-            this.btnOpenCache.Location = new System.Drawing.Point(308, 99);
-            this.btnOpenCache.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOpenCache.Location = new System.Drawing.Point(231, 80);
             this.btnOpenCache.Name = "btnOpenCache";
-            this.btnOpenCache.Size = new System.Drawing.Size(203, 28);
+            this.btnOpenCache.Size = new System.Drawing.Size(152, 23);
             this.btnOpenCache.TabIndex = 16;
             this.btnOpenCache.Text = "Open Cache Location";
             this.btnOpenCache.UseVisualStyleBackColor = true;
@@ -330,10 +320,9 @@ namespace ScreenSaver
             // chkCacheVideos
             // 
             this.chkCacheVideos.AutoSize = true;
-            this.chkCacheVideos.Location = new System.Drawing.Point(8, 23);
-            this.chkCacheVideos.Margin = new System.Windows.Forms.Padding(4);
+            this.chkCacheVideos.Location = new System.Drawing.Point(6, 19);
             this.chkCacheVideos.Name = "chkCacheVideos";
-            this.chkCacheVideos.Size = new System.Drawing.Size(199, 21);
+            this.chkCacheVideos.Size = new System.Drawing.Size(154, 17);
             this.chkCacheVideos.TabIndex = 13;
             this.chkCacheVideos.Text = "Cache videos while playing";
             this.chkCacheVideos.UseVisualStyleBackColor = true;
@@ -341,10 +330,9 @@ namespace ScreenSaver
             // changeCacheLocationButton
             // 
             this.changeCacheLocationButton.Enabled = false;
-            this.changeCacheLocationButton.Location = new System.Drawing.Point(308, 171);
-            this.changeCacheLocationButton.Margin = new System.Windows.Forms.Padding(4);
+            this.changeCacheLocationButton.Location = new System.Drawing.Point(231, 139);
             this.changeCacheLocationButton.Name = "changeCacheLocationButton";
-            this.changeCacheLocationButton.Size = new System.Drawing.Size(203, 28);
+            this.changeCacheLocationButton.Size = new System.Drawing.Size(152, 23);
             this.changeCacheLocationButton.TabIndex = 15;
             this.changeCacheLocationButton.Text = "Change Cache Location...";
             this.changeCacheLocationButton.UseVisualStyleBackColor = true;
@@ -354,11 +342,10 @@ namespace ScreenSaver
             // 
             this.txtCacheFolderPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtCacheFolderPath.Location = new System.Drawing.Point(8, 174);
-            this.txtCacheFolderPath.Margin = new System.Windows.Forms.Padding(4);
+            this.txtCacheFolderPath.Location = new System.Drawing.Point(6, 141);
             this.txtCacheFolderPath.Name = "txtCacheFolderPath";
             this.txtCacheFolderPath.ReadOnly = true;
-            this.txtCacheFolderPath.Size = new System.Drawing.Size(290, 22);
+            this.txtCacheFolderPath.Size = new System.Drawing.Size(218, 20);
             this.txtCacheFolderPath.TabIndex = 14;
             // 
             // tabSource
@@ -367,20 +354,31 @@ namespace ScreenSaver
             this.tabSource.Controls.Add(this.videoSourceResetButton);
             this.tabSource.Controls.Add(this.lbl_VideoSourceURL);
             this.tabSource.Controls.Add(this.changeVideoSourceText);
-            this.tabSource.Location = new System.Drawing.Point(4, 25);
-            this.tabSource.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tabSource.Location = new System.Drawing.Point(4, 22);
+            this.tabSource.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tabSource.Name = "tabSource";
-            this.tabSource.Size = new System.Drawing.Size(539, 415);
+            this.tabSource.Size = new System.Drawing.Size(402, 335);
             this.tabSource.TabIndex = 3;
             this.tabSource.Text = "Video Source";
             this.tabSource.UseVisualStyleBackColor = true;
             // 
+            // SetToFourK_btn
+            // 
+            this.SetToFourK_btn.Location = new System.Drawing.Point(248, 60);
+            this.SetToFourK_btn.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.SetToFourK_btn.Name = "SetToFourK_btn";
+            this.SetToFourK_btn.Size = new System.Drawing.Size(140, 22);
+            this.SetToFourK_btn.TabIndex = 26;
+            this.SetToFourK_btn.Text = "Set to 4k Video";
+            this.SetToFourK_btn.UseVisualStyleBackColor = true;
+            this.SetToFourK_btn.Click += new System.EventHandler(this.SetToFourK_btn_Click);
+            // 
             // videoSourceResetButton
             // 
-            this.videoSourceResetButton.Location = new System.Drawing.Point(15, 72);
-            this.videoSourceResetButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.videoSourceResetButton.Location = new System.Drawing.Point(11, 58);
+            this.videoSourceResetButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.videoSourceResetButton.Name = "videoSourceResetButton";
-            this.videoSourceResetButton.Size = new System.Drawing.Size(189, 27);
+            this.videoSourceResetButton.Size = new System.Drawing.Size(142, 22);
             this.videoSourceResetButton.TabIndex = 25;
             this.videoSourceResetButton.Text = "Set to Standard Videos";
             this.videoSourceResetButton.UseVisualStyleBackColor = true;
@@ -389,9 +387,10 @@ namespace ScreenSaver
             // lbl_VideoSourceURL
             // 
             this.lbl_VideoSourceURL.AutoSize = true;
-            this.lbl_VideoSourceURL.Location = new System.Drawing.Point(12, 17);
+            this.lbl_VideoSourceURL.Location = new System.Drawing.Point(9, 14);
+            this.lbl_VideoSourceURL.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lbl_VideoSourceURL.Name = "lbl_VideoSourceURL";
-            this.lbl_VideoSourceURL.Size = new System.Drawing.Size(373, 17);
+            this.lbl_VideoSourceURL.Size = new System.Drawing.Size(279, 13);
             this.lbl_VideoSourceURL.TabIndex = 24;
             this.lbl_VideoSourceURL.Text = "Video Source URL (change requires restart to take effect)";
             // 
@@ -399,18 +398,16 @@ namespace ScreenSaver
             // 
             this.changeVideoSourceText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.changeVideoSourceText.Location = new System.Drawing.Point(15, 45);
-            this.changeVideoSourceText.Margin = new System.Windows.Forms.Padding(4);
+            this.changeVideoSourceText.Location = new System.Drawing.Point(11, 37);
             this.changeVideoSourceText.Name = "changeVideoSourceText";
-            this.changeVideoSourceText.Size = new System.Drawing.Size(503, 22);
+            this.changeVideoSourceText.Size = new System.Drawing.Size(378, 20);
             this.changeVideoSourceText.TabIndex = 23;
             // 
             // tabAbout
             // 
-            this.tabAbout.Location = new System.Drawing.Point(4, 25);
-            this.tabAbout.Margin = new System.Windows.Forms.Padding(4);
+            this.tabAbout.Location = new System.Drawing.Point(4, 22);
             this.tabAbout.Name = "tabAbout";
-            this.tabAbout.Size = new System.Drawing.Size(539, 415);
+            this.tabAbout.Size = new System.Drawing.Size(402, 335);
             this.tabAbout.TabIndex = 2;
             this.tabAbout.Text = "About";
             this.tabAbout.UseVisualStyleBackColor = true;
@@ -421,37 +418,17 @@ namespace ScreenSaver
             this.timerDiskUpdate.Interval = 1000;
             this.timerDiskUpdate.Tick += new System.EventHandler(this.timerDiskUpdate_Tick);
             // 
-            // cbMultiScreenMode
-            // 
-            this.cbMultiScreenMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbMultiScreenMode.FormattingEnabled = true;
-            this.cbMultiScreenMode.Location = new System.Drawing.Point(7, 24);
-            this.cbMultiScreenMode.Name = "cbMultiScreenMode";
-            this.cbMultiScreenMode.Size = new System.Drawing.Size(377, 21);
-            this.cbMultiScreenMode.TabIndex = 0;
-            // 
-            // SetToFourK_btn
-            // 
-            this.SetToFourK_btn.Location = new System.Drawing.Point(331, 74);
-            this.SetToFourK_btn.Name = "SetToFourK_btn";
-            this.SetToFourK_btn.Size = new System.Drawing.Size(187, 27);
-            this.SetToFourK_btn.TabIndex = 26;
-            this.SetToFourK_btn.Text = "Set to 4k Video";
-            this.SetToFourK_btn.UseVisualStyleBackColor = true;
-            this.SetToFourK_btn.Click += new System.EventHandler(this.SetToFourK_btn_Click);
-            // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(579, 516);
+            this.ClientSize = new System.Drawing.Size(434, 419);
             this.Controls.Add(this.tabs);
             this.Controls.Add(this.lblVersion);
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.okButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "SettingsForm";
@@ -467,7 +444,6 @@ namespace ScreenSaver
             ((System.ComponentModel.ISupportInitialize)(this.player)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
             this.tabCache.ResumeLayout(false);
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();

--- a/ScreenSaver/SettingsForm.Designer.cs
+++ b/ScreenSaver/SettingsForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace ScreenSaver
+namespace ScreenSaver
 {
     partial class SettingsForm
     {
@@ -43,8 +43,6 @@
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.chkUseTimeOfDay = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.chkMultiscreenDisabled = new System.Windows.Forms.CheckBox();
-            this.chkDifferentMonitorMovies = new System.Windows.Forms.CheckBox();
             this.tabCache = new System.Windows.Forms.TabPage();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.numOfCurrDown_lbl = new System.Windows.Forms.Label();
@@ -63,6 +61,7 @@
             this.tabAbout = new System.Windows.Forms.TabPage();
             this.timerDiskUpdate = new System.Windows.Forms.Timer(this.components);
             this.SetToFourK_btn = new System.Windows.Forms.Button();
+            this.cbMultiScreenMode = new System.Windows.Forms.ComboBox();
             this.tabs.SuspendLayout();
             this.tabPreferences.SuspendLayout();
             this.grpChosenVideos.SuspendLayout();
@@ -224,8 +223,7 @@
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.chkMultiscreenDisabled);
-            this.groupBox1.Controls.Add(this.chkDifferentMonitorMovies);
+            this.groupBox1.Controls.Add(this.cbMultiScreenMode);
             this.groupBox1.Location = new System.Drawing.Point(8, 7);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox1.Name = "groupBox1";
@@ -234,32 +232,6 @@
             this.groupBox1.TabIndex = 12;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Multi-screen setups";
-            // 
-            // chkMultiscreenDisabled
-            // 
-            this.chkMultiscreenDisabled.AutoSize = true;
-            this.chkMultiscreenDisabled.Checked = true;
-            this.chkMultiscreenDisabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkMultiscreenDisabled.Location = new System.Drawing.Point(8, 52);
-            this.chkMultiscreenDisabled.Margin = new System.Windows.Forms.Padding(4);
-            this.chkMultiscreenDisabled.Name = "chkMultiscreenDisabled";
-            this.chkMultiscreenDisabled.Size = new System.Drawing.Size(328, 21);
-            this.chkMultiscreenDisabled.TabIndex = 14;
-            this.chkMultiscreenDisabled.Text = "Show only on main screen on 3+ screen setups";
-            this.chkMultiscreenDisabled.UseVisualStyleBackColor = true;
-            // 
-            // chkDifferentMonitorMovies
-            // 
-            this.chkDifferentMonitorMovies.AutoSize = true;
-            this.chkDifferentMonitorMovies.Checked = true;
-            this.chkDifferentMonitorMovies.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDifferentMonitorMovies.Location = new System.Drawing.Point(8, 23);
-            this.chkDifferentMonitorMovies.Margin = new System.Windows.Forms.Padding(4);
-            this.chkDifferentMonitorMovies.Name = "chkDifferentMonitorMovies";
-            this.chkDifferentMonitorMovies.Size = new System.Drawing.Size(253, 21);
-            this.chkDifferentMonitorMovies.TabIndex = 12;
-            this.chkDifferentMonitorMovies.Text = "Play different video on each screen";
-            this.chkDifferentMonitorMovies.UseVisualStyleBackColor = true;
             // 
             // tabCache
             // 
@@ -449,6 +421,15 @@
             this.timerDiskUpdate.Interval = 1000;
             this.timerDiskUpdate.Tick += new System.EventHandler(this.timerDiskUpdate_Tick);
             // 
+            // cbMultiScreenMode
+            // 
+            this.cbMultiScreenMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbMultiScreenMode.FormattingEnabled = true;
+            this.cbMultiScreenMode.Location = new System.Drawing.Point(7, 24);
+            this.cbMultiScreenMode.Name = "cbMultiScreenMode";
+            this.cbMultiScreenMode.Size = new System.Drawing.Size(377, 21);
+            this.cbMultiScreenMode.TabIndex = 0;
+            // 
             // SetToFourK_btn
             // 
             this.SetToFourK_btn.Location = new System.Drawing.Point(331, 74);
@@ -509,8 +490,6 @@
         private System.Windows.Forms.CheckBox chkCacheVideos;
         private System.Windows.Forms.TabPage tabAbout;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.CheckBox chkMultiscreenDisabled;
-        private System.Windows.Forms.CheckBox chkDifferentMonitorMovies;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.GroupBox grpChosenVideos;
         private System.Windows.Forms.CheckBox chkUseTimeOfDay;
@@ -530,5 +509,6 @@
         private System.Windows.Forms.Button fullDownloadBtn;
         private System.Windows.Forms.Label numOfCurrDown_lbl;
         private System.Windows.Forms.Button SetToFourK_btn;
+        private System.Windows.Forms.ComboBox cbMultiScreenMode;
     }
 }

--- a/ScreenSaver/SettingsForm.cs
+++ b/ScreenSaver/SettingsForm.cs
@@ -15,8 +15,9 @@ namespace ScreenSaver
         public SettingsForm()
         {
             InitializeComponent();
+            
             LoadSettings();
-
+            
             //timer to update the number of current downloads every second
             var myTimer = new Timer();
             myTimer.Tick += new EventHandler(updateNumCurrDownloads);
@@ -30,12 +31,13 @@ namespace ScreenSaver
         private void LoadSettings()
         {
             var settings = new RegSettings();
-            chkDifferentMonitorMovies.Checked = settings.DifferentMoviesOnDual;
+            //chkDifferentMonitorMovies.Checked = settings.DifferentMoviesOnDual;
             chkUseTimeOfDay.Checked = settings.UseTimeOfDay;
-            chkMultiscreenDisabled.Checked = settings.MultiscreenDisabled;
+            //chkMultiscreenDisabled.Checked = settings.MultiscreenDisabled;
             chkCacheVideos.Checked = settings.CacheVideos;
+            cbMultiScreenMode.DataBindEnum(settings.MultiMonitorMode);
 
-            if(settings.CacheLocation == null || settings.CacheLocation == "")
+            if (settings.CacheLocation == null || settings.CacheLocation == "")
             {
                 txtCacheFolderPath.Text = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Aerial").ToString();
             }
@@ -150,9 +152,8 @@ namespace ScreenSaver
         private void SaveSettings()
         {
             var settings = new RegSettings();
-            settings.DifferentMoviesOnDual = chkDifferentMonitorMovies.Checked;
+            settings.MultiMonitorMode = (RegSettings.MultiMonitorModeEnum)cbMultiScreenMode.SelectedValue;
             settings.UseTimeOfDay = chkUseTimeOfDay.Checked;
-            settings.MultiscreenDisabled = chkMultiscreenDisabled.Checked;
             settings.CacheVideos = chkCacheVideos.Checked;
 
             string oldCacheDirectory = settings.CacheLocation;


### PR DESCRIPTION
Adds a new "Span single video across all monitors" option.

* This picks the outer bounds of all monitors, then proportionally resizes the video to fit inside. 
  * This means in the case of two side-by-side monitors (seen below), for example, the top and bottom of the video is cut off

![image](https://user-images.githubusercontent.com/1216375/48110369-b98ebf80-e219-11e8-8be6-9147bc40f955.png)

* Replaces `DifferentMoviesOnDual` and `MultiscreenDisabled` settings with `MultiMonitorMode`
  * Old settings are migrated to new mode
  * Old registry keys removed upon saving settings

![image](https://user-images.githubusercontent.com/1216375/48110437-21dda100-e21a-11e8-8fc8-a0bb64588f77.png)

*  Refactors main invocation code to simplify different modes

Implements #133
