### PR TITLE
Added a redirect to OrangeJedi/Aerial

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,9 @@
 </a>
 </p>
 
+## 🚨 This project is no longer supported 🚨
+Use [OrangeJedi/Aerial](https://github.com/OrangeJedi/Aerial) as a replacement. It is a re-write of Aerial that has updated videos and additional features.
+
 ## Aerial - Apple TV Aerial Views Screen Saver for Windows 7, 8, 10+
 Aerial is a Windows screen saver based on the new Apple TV screen saver that displays the aerial movies Apple shot over New York, San Francisco, Hawaii, China, etc.
 


### PR DESCRIPTION
Adds a message to the readme directing users to go to the OrangeJedi/Aerial repository.